### PR TITLE
Fix #7: increase FPS spinbox maximum to 999

### DIFF
--- a/src/common/qprojectmconfigdialog.ui
+++ b/src/common/qprojectmconfigdialog.ui
@@ -296,6 +296,9 @@ p, li { white-space: pre-wrap; }
       <property name="minimum">
        <number>0</number>
       </property>
+      <property name="maximum">
+       <number>999</number>
+      </property>
      </widget>
     </item>
     <item row="6" column="0" colspan="2">


### PR DESCRIPTION
Closes #7

## Summary

The `maxFPSSpinBox` in the config dialog had no explicit `maximum` property, defaulting to Qt's `QSpinBox` default of 99. Users with high-refresh displays (120/144/240 Hz) could set FPS > 99 in `config.inp`, but the UI clamped it back to 99 on save.

## Change

Added `<maximum>999</maximum>` to the spinbox.

## Test plan
- [x] Build clean
- [x] Open config dialog, FPS field accepts values up to 999