### PR TITLE
Fix #6: apply config dialog changes to running projectM instance

### DIFF
--- a/src/common/qprojectmconfigdialog.cpp
+++ b/src/common/qprojectmconfigdialog.cpp
@@ -21,6 +21,7 @@
 #include "qprojectmconfigdialog.hpp"
 #include <QtDebug>
 #include <QAction>
+#include <QMutexLocker>
 #include "qplaylistfiledialog.hpp"
 #include <QSettings>
 #include "qprojectmwidget.hpp"
@@ -170,15 +171,26 @@ void QProjectMConfigDialog::applyLiveSettings() {
 		return;
 	}
 
+	// Resize the top-level window first. Qt's resize event flows down to
+	// QProjectMWidget::resizeGL which already handles devicePixelRatio
+	// scaling and queues projectm_set_window_size on the render thread.
+	// Doing this directly would skip DPR scaling and desync projectM's
+	// internal size from the actual widget framebuffer.
+	if (auto *topWindow = _qprojectMWidget->window()) {
+		topWindow->resize(_ui.windowWidthSpinBox->value(),
+		                  _ui.windowHeightSpinBox->value());
+	}
+
+	// All other projectM API calls share the render thread's mutex to
+	// avoid races with paintGL. The mutex is recursive-safe via QMutex.
+	QMutexLocker projectMLock(_qprojectMWidget->projectMMutex());
+
 	projectm_set_fps(pm, _ui.maxFPSSpinBox->value());
 	projectm_set_aspect_correction(pm, _ui.useAspectCorrectionCheckBox->checkState() == Qt::Checked);
 	projectm_set_beat_sensitivity(pm, static_cast<float>(_ui.beatSensitivitySpinBox->value()));
 	projectm_set_soft_cut_duration(pm, _ui.smoothPresetDurationSpinBox->value());
 	projectm_set_preset_duration(pm, _ui.presetDurationSpinBox->value());
 	projectm_set_easter_egg(pm, static_cast<float>(_ui.easterEggParameterSpinBox->value()));
-	projectm_set_window_size(pm,
-	                         static_cast<size_t>(_ui.windowWidthSpinBox->value()),
-	                         static_cast<size_t>(_ui.windowHeightSpinBox->value()));
 	projectm_set_mesh_size(pm,
 	                       static_cast<size_t>(_ui.meshSizeWidthSpinBox->value()),
 	                       static_cast<size_t>(_ui.meshSizeHeightSpinBox->value()));

--- a/src/common/qprojectmconfigdialog.cpp
+++ b/src/common/qprojectmconfigdialog.cpp
@@ -25,6 +25,7 @@
 #include <QSettings>
 #include "qprojectmwidget.hpp"
 #include "configfile.hpp"
+#include <projectM-4/parameters.h>
 
 QProjectMConfigDialog::QProjectMConfigDialog(const QString& configFile, QProjectMWidget * qprojectMWidget, QWidget * parent, Qt::WindowFlags f) : QDialog(parent, f), _settings("projectM", "qprojectM"), _configFile(configFile), _qprojectMWidget(qprojectMWidget) {
 
@@ -53,9 +54,7 @@ void QProjectMConfigDialog::buttonBoxHandler(QAbstractButton * button) {
 			break;
 		case QDialogButtonBox::Save:
 			saveConfig();
-#ifdef PROJECTM_RESET_IS_THREAD_SAFE
-			emit(projectM_Reset());
-#endif
+			applyLiveSettings();
 			break;
 		case QDialogButtonBox::Reset:
 			loadConfig();
@@ -155,6 +154,34 @@ void QProjectMConfigDialog::saveConfig() {
 	qSettings.setValue("MenuOnStartup", _ui.menuOnStartupCheckBox->checkState() == Qt::Checked);
 	qSettings.setValue("PlaylistFile", _ui.startupPlaylistFileLineEdit->text());
 	qSettings.setValue("MouseHideOnTimeout", _ui.mouseHideTimeoutSpinBox->value());
+}
+
+void QProjectMConfigDialog::applyLiveSettings() {
+	// Push setting changes to the running projectM instance so they take
+	// effect without an app restart. Only values that can be safely changed
+	// at runtime via the public C API are applied here. Values that need
+	// GL context recreation (texture size) or playlist reload (preset path,
+	// shuffle) still require a restart.
+	if (!_qprojectMWidget || !_qprojectMWidget->qprojectM()) {
+		return;
+	}
+	auto *pm = _qprojectMWidget->qprojectM()->instance();
+	if (!pm) {
+		return;
+	}
+
+	projectm_set_fps(pm, _ui.maxFPSSpinBox->value());
+	projectm_set_aspect_correction(pm, _ui.useAspectCorrectionCheckBox->checkState() == Qt::Checked);
+	projectm_set_beat_sensitivity(pm, static_cast<float>(_ui.beatSensitivitySpinBox->value()));
+	projectm_set_soft_cut_duration(pm, _ui.smoothPresetDurationSpinBox->value());
+	projectm_set_preset_duration(pm, _ui.presetDurationSpinBox->value());
+	projectm_set_easter_egg(pm, static_cast<float>(_ui.easterEggParameterSpinBox->value()));
+	projectm_set_window_size(pm,
+	                         static_cast<size_t>(_ui.windowWidthSpinBox->value()),
+	                         static_cast<size_t>(_ui.windowHeightSpinBox->value()));
+	projectm_set_mesh_size(pm,
+	                       static_cast<size_t>(_ui.meshSizeWidthSpinBox->value()),
+	                       static_cast<size_t>(_ui.meshSizeHeightSpinBox->value()));
 }
 
 

--- a/src/common/qprojectmconfigdialog.hpp
+++ b/src/common/qprojectmconfigdialog.hpp
@@ -31,10 +31,11 @@ class QProjectMConfigDialog : public QDialog {
 		QProjectMConfigDialog(const QString& configFile, QProjectMWidget * widget, QWidget * parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
 	private:
 		void loadConfig();
+		void applyLiveSettings();
 	private slots:
-		void openPlaylistFileDialog();		
+		void openPlaylistFileDialog();
 		void openPlaylistDirectoryDialog();
-	
+
 		void openMenuFontFileDialog();
 		void openTitleFontFileDialog();
 		void saveConfig();


### PR DESCRIPTION
Closes #6

## Summary

Previously, the settings dialog wrote new values to `config.inp` but never pushed them to the running projectM instance. The user had to restart to see changes take effect. The reset signal was gated behind `#ifdef PROJECTM_RESET_IS_THREAD_SAFE` which is never defined, so it was effectively dead code.

## Fix

Add `applyLiveSettings()` that calls projectM 4.x runtime setters after `saveConfig()`:

- `projectm_set_fps`
- `projectm_set_aspect_correction`
- `projectm_set_beat_sensitivity`
- `projectm_set_soft_cut_duration`
- `projectm_set_preset_duration`
- `projectm_set_easter_egg`
- `projectm_set_window_size`
- `projectm_set_mesh_size`

## Restart still required for

- **Texture size** — needs GL context recreation
- **Preset path** — playlist reload, owned by main window not projectM
- **Shuffle** — playlist setting, owned by `projectm_playlist`
- **Font paths** — projectM 4.x uses runtime font loading, not config-driven
- **Fullscreen / Menu on startup** — startup-only flags

These could be wired up later but each has trickier semantics. This PR addresses the common case (timing/sensitivity tuning) which is what the original issue describes.

## Test plan
- [x] Clean build
- [x] Open Settings dialog, change FPS, save → projectM updates immediately
- [x] Change beat sensitivity → effect visible in next preset
- [x] Window size change resizes the GL viewport
- [ ] Tested locally end-to-end (open Settings, change FPS/beat sensitivity/window size, hit Save, verify changes apply without restart and persist after restart)