### PR TITLE
Fix #3: suppress status tips from playlist dock when floating

### DIFF
--- a/src/common/qprojectm_mainwindow.cpp
+++ b/src/common/qprojectm_mainwindow.cpp
@@ -115,6 +115,13 @@ m_QPlaylistFileDialog( new QPlaylistFileDialog ( this ))
 	setCentralWidget ( m_QProjectMWidget );
 	m_QProjectMWidget->installEventFilter(this);
 
+	// When the playlist dock is floating on a separate screen, hover events
+	// would otherwise propagate status tips to the main window's status bar
+	// (issue #3). Filter them at the dock so the info doesn't appear on the
+	// wrong screen.
+	ui->presetPlayListDockWidget->installEventFilter(this);
+	ui->tableView->installEventFilter(this);
+
 	m_timer->start ( 0 );
 
 	createActions();
@@ -1407,7 +1414,14 @@ void QProjectM_MainWindow::handleFailedPresetSwitch(const QString & filename, co
 
 bool QProjectM_MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
-    Q_UNUSED(obj);
+	// Suppress status tips originating from the playlist when the dock is
+	// floating on a different screen, so they don't appear on the main
+	// window's status bar (issue #3).
+	if (event->type() == QEvent::StatusTip
+	    && ui->presetPlayListDockWidget->isFloating()
+	    && (obj == ui->presetPlayListDockWidget || obj == ui->tableView)) {
+		return true;
+	}
 
 	if (event->type() == QEvent::MouseButtonDblClick && ((QMouseEvent*)event)->button() == Qt::LeftButton) {
 		this->setWindowState ( this->windowState() ^ Qt::WindowFullScreen );


### PR DESCRIPTION
Closes #3

## Summary

When the preset playlist dock widget is undocked and moved to a second screen (typical "beamer/projector + control monitor" setup), hovering over preset items causes the info text to appear in the **main window's** status bar — on the wrong screen. The user wants the info to stay with the playlist window or not show at all on the visualization screen.

## Fix

Install an event filter on `presetPlayListDockWidget` and the `tableView` that consumes `QEvent::StatusTip` when the dock is floating. The events would otherwise propagate up the QObject parent chain to the main window's status bar.

Tooltips (the floating yellow popup boxes) still work normally and follow the cursor to the correct screen via Qt's window manager hints.

## Test plan
- [x] Clean build
- [ ] Dual-monitor: undock playlist, drag to second screen, hover over presets — main window's status bar no longer shows the hover text *(needs manual verification on a multi-monitor system)*
- [ ] Tested locally end-to-end (dual-monitor: undock playlist, move to second screen, hover over presets, verify main window's status bar stays empty)