### PR TITLE
Unified executable with runtime audio backend selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 tmp/
 .claude/
+build-*/
+*.log

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,9 @@ if(ENABLE_JACK)
     add_subdirectory(ui-jack)
 endif()
 
-if(NOT ENABLE_PULSEAUDIO AND NOT ENABLE_PIPEWIRE AND NOT ENABLE_JACK)
+# Unified executable with runtime backend selection
+if(ENABLE_PULSEAUDIO OR ENABLE_PIPEWIRE OR ENABLE_JACK)
+    add_subdirectory(ui-unified)
+else()
     message(FATAL_ERROR "At least one audio backend must be enabled (ENABLE_PULSEAUDIO, ENABLE_PIPEWIRE, or ENABLE_JACK).")
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -3,6 +3,13 @@ add_library(projectM-Qt-Common STATIC
         configfile.cpp
         configfile.hpp
         nullable.hpp
+        QAudioBackend.hpp
+        QAudioDeviceChooser.cpp
+        QAudioDeviceChooser.hpp
+        QAudioDeviceModel.cpp
+        QAudioDeviceModel.hpp
+        configutil.cpp
+        configutil.hpp
         qplaylistfiledialog.cpp
         qplaylistfiledialog.hpp
         qplaylistmodel.cpp

--- a/src/common/QAudioBackend.hpp
+++ b/src/common/QAudioBackend.hpp
@@ -18,11 +18,14 @@ public:
         QString displayName;
     };
 
-    explicit QAudioBackend(QObject *parent = nullptr) : QObject(parent) {}
+    explicit QAudioBackend(QObject *parent = nullptr) : QObject(parent), m_active(false) {}
     virtual ~QAudioBackend() {}
 
     virtual bool start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex) = 0;
     virtual void stop() = 0;
+
+    bool isActive() const { return m_active; }
+    void setActive(bool active) { m_active = active; }
 
     virtual QString backendName() const = 0;
 
@@ -32,6 +35,9 @@ public:
 
     virtual void writeSettings() = 0;
     virtual void readSettings() = 0;
+
+protected:
+    bool m_active;
 
 public slots:
     virtual void selectDevice(const QString &deviceId) = 0;

--- a/src/common/QAudioBackend.hpp
+++ b/src/common/QAudioBackend.hpp
@@ -1,0 +1,45 @@
+#ifndef QAUDIO_BACKEND_HPP
+#define QAUDIO_BACKEND_HPP
+
+#include <QObject>
+#include <QString>
+#include <QList>
+
+class QProjectM_MainWindow;
+class QMutex;
+
+class QAudioBackend : public QObject
+{
+    Q_OBJECT
+
+public:
+    struct DeviceInfo {
+        QString id;
+        QString displayName;
+    };
+
+    explicit QAudioBackend(QObject *parent = nullptr) : QObject(parent) {}
+    virtual ~QAudioBackend() {}
+
+    virtual bool start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex) = 0;
+    virtual void stop() = 0;
+
+    virtual QString backendName() const = 0;
+
+    virtual QList<DeviceInfo> devices() const = 0;
+    virtual QString currentDeviceId() const = 0;
+    virtual bool supportsDeviceSwitching() const = 0;
+
+    virtual void writeSettings() = 0;
+    virtual void readSettings() = 0;
+
+public slots:
+    virtual void selectDevice(const QString &deviceId) = 0;
+
+signals:
+    void devicesChanged();
+    void activeDeviceChanged();
+    void errorOccurred(const QString &message);
+};
+
+#endif // QAUDIO_BACKEND_HPP

--- a/src/common/QAudioDeviceChooser.cpp
+++ b/src/common/QAudioDeviceChooser.cpp
@@ -1,0 +1,148 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "QAudioDeviceChooser.hpp"
+#include "QAudioDeviceModel.hpp"
+#include "QAudioBackend.hpp"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QListView>
+#include <QSettings>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QtDebug>
+
+QAudioDeviceChooser::QAudioDeviceChooser(QAudioBackend *backend, QWidget *parent)
+    : QDialog(parent),
+      m_backend(backend),
+      m_deviceModel(new QAudioDeviceModel(backend, this)),
+      m_devicesListView(nullptr),
+      m_autoDetectCheckBox(nullptr),
+      m_infoLabel(nullptr)
+{
+    buildUi();
+    readSettings();
+}
+
+void QAudioDeviceChooser::buildUi()
+{
+    setWindowTitle(tr("Audio Device Settings"));
+    resize(380, 271);
+
+    QVBoxLayout *mainVBox = new QVBoxLayout();
+
+    // Info / instruction label
+    m_infoLabel = new QLabel(tr("Select a source device below."), this);
+    mainVBox->addWidget(m_infoLabel);
+
+    // Device list view
+    m_devicesListView = new QListView(this);
+    m_devicesListView->setAutoFillBackground(true);
+    m_devicesListView->setToolTip(tr("Double click a source device to activate it."));
+    m_devicesListView->setModel(m_deviceModel);
+    mainVBox->addWidget(m_devicesListView);
+
+    // Auto-detect checkbox
+    m_autoDetectCheckBox = new QCheckBox(tr("Auto-detect best source"), this);
+    m_autoDetectCheckBox->setToolTip(
+        tr("Automatically select the best available audio source on startup. "
+           "This is the recommended way to get projectM to visualize sound "
+           "without specifying a device explicitly."));
+    mainVBox->addWidget(m_autoDetectCheckBox);
+
+    // If the backend does not support device switching, disable the list
+    if (!m_backend->supportsDeviceSwitching()) {
+        m_devicesListView->setEnabled(false);
+        m_autoDetectCheckBox->setEnabled(false);
+        m_infoLabel->setText(
+            tr("This audio backend does not support device switching."));
+    }
+
+    // Horizontal layout: main content + button box
+    QHBoxLayout *hBox = new QHBoxLayout(this);
+    hBox->addLayout(mainVBox);
+
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(
+        QDialogButtonBox::Ok, Qt::Vertical, this);
+    hBox->addWidget(buttonBox);
+
+    setLayout(hBox);
+
+    // Connections
+    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+
+    connect(m_autoDetectCheckBox, SIGNAL(stateChanged(int)),
+            this, SLOT(onAutoDetectToggled(int)));
+
+    connect(m_devicesListView, SIGNAL(doubleClicked(const QModelIndex&)),
+            this, SLOT(onDeviceDoubleClicked(const QModelIndex&)));
+}
+
+void QAudioDeviceChooser::onAutoDetectToggled(int state)
+{
+    m_devicesListView->setEnabled(state != Qt::Checked);
+}
+
+void QAudioDeviceChooser::onDeviceDoubleClicked(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+
+    QString deviceId = index.data(QAudioDeviceModel::DeviceIdRole).toString();
+    if (!deviceId.isEmpty()) {
+        m_backend->selectDevice(deviceId);
+    }
+}
+
+void QAudioDeviceChooser::writeSettings()
+{
+    QSettings settings("projectM", "qprojectM");
+    settings.setValue("audioDeviceChooser/autoDetect",
+                      m_autoDetectCheckBox->checkState() == Qt::Checked);
+
+    QString currentId = m_backend->currentDeviceId();
+    if (!currentId.isEmpty()) {
+        settings.setValue("audioDeviceChooser/deviceId", currentId);
+    }
+}
+
+void QAudioDeviceChooser::readSettings()
+{
+    QSettings settings("projectM", "qprojectM");
+
+    bool autoDetect = settings.value("audioDeviceChooser/autoDetect", true).toBool();
+    m_autoDetectCheckBox->setCheckState(autoDetect ? Qt::Checked : Qt::Unchecked);
+
+    if (autoDetect) {
+        m_devicesListView->setEnabled(false);
+    } else {
+        m_devicesListView->setEnabled(true);
+    }
+}
+
+void QAudioDeviceChooser::open()
+{
+    m_deviceModel->refresh();
+    show();
+}

--- a/src/common/QAudioDeviceChooser.hpp
+++ b/src/common/QAudioDeviceChooser.hpp
@@ -1,0 +1,60 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#ifndef QAUDIO_DEVICE_CHOOSER_HPP
+#define QAUDIO_DEVICE_CHOOSER_HPP
+
+#include <QDialog>
+
+class QAudioBackend;
+class QAudioDeviceModel;
+class QListView;
+class QCheckBox;
+class QLabel;
+
+class QAudioDeviceChooser : public QDialog
+{
+    Q_OBJECT
+
+public:
+    QAudioDeviceChooser(QAudioBackend *backend, QWidget *parent = nullptr);
+
+public slots:
+    void open();
+    void writeSettings();
+
+private slots:
+    void readSettings();
+    void onAutoDetectToggled(int state);
+    void onDeviceDoubleClicked(const QModelIndex &index);
+
+private:
+    void buildUi();
+
+    QAudioBackend *m_backend;
+    QAudioDeviceModel *m_deviceModel;
+
+    QListView *m_devicesListView;
+    QCheckBox *m_autoDetectCheckBox;
+    QLabel *m_infoLabel;
+};
+
+#endif // QAUDIO_DEVICE_CHOOSER_HPP

--- a/src/common/QAudioDeviceModel.cpp
+++ b/src/common/QAudioDeviceModel.cpp
@@ -1,0 +1,83 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "QAudioDeviceModel.hpp"
+#include "QAudioBackend.hpp"
+
+#include <QColor>
+
+QAudioDeviceModel::QAudioDeviceModel(QAudioBackend *backend, QObject *parent)
+    : QAbstractListModel(parent), m_backend(backend)
+{
+    connect(m_backend, SIGNAL(devicesChanged()), this, SLOT(refresh()));
+    connect(m_backend, SIGNAL(activeDeviceChanged()), this, SLOT(refresh()));
+}
+
+QAudioDeviceModel::~QAudioDeviceModel()
+{
+}
+
+void QAudioDeviceModel::refresh()
+{
+    beginResetModel();
+    endResetModel();
+}
+
+int QAudioDeviceModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return m_backend->devices().size();
+}
+
+QVariant QAudioDeviceModel::data(const QModelIndex &index, int role) const
+{
+    QList<QAudioBackend::DeviceInfo> devs = m_backend->devices();
+
+    if (!index.isValid() || index.row() >= devs.size())
+        return QVariant();
+
+    const QAudioBackend::DeviceInfo &info = devs[index.row()];
+
+    switch (role)
+    {
+        case Qt::DisplayRole:
+            return info.displayName;
+
+        case Qt::ToolTipRole:
+            if (info.id == m_backend->currentDeviceId())
+                return info.displayName + " (active)";
+            else
+                return info.displayName;
+
+        case Qt::BackgroundRole:
+            if (info.id == m_backend->currentDeviceId()) {
+                QColor highlight(0, 200, 0, 80);
+                return highlight;
+            }
+            return QVariant();
+
+        case DeviceIdRole:
+            return info.id;
+
+        default:
+            return QVariant();
+    }
+}

--- a/src/common/QAudioDeviceModel.hpp
+++ b/src/common/QAudioDeviceModel.hpp
@@ -1,0 +1,51 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#ifndef QAUDIO_DEVICE_MODEL_HPP
+#define QAUDIO_DEVICE_MODEL_HPP
+
+#include <QAbstractListModel>
+
+class QAudioBackend;
+
+class QAudioDeviceModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum Roles {
+        DeviceIdRole = Qt::UserRole + 1
+    };
+
+    explicit QAudioDeviceModel(QAudioBackend *backend, QObject *parent = nullptr);
+    ~QAudioDeviceModel();
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+
+public slots:
+    void refresh();
+
+private:
+    QAudioBackend *m_backend;
+};
+
+#endif // QAUDIO_DEVICE_MODEL_HPP

--- a/src/common/configutil.cpp
+++ b/src/common/configutil.cpp
@@ -1,0 +1,77 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "configutil.hpp"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QtDebug>
+
+static const char* CONFIG_FILE = "/share/projectM/config.inp";
+
+QString readProjectMConfig(const QString &installPrefix)
+{
+    QString defaultConfig = installPrefix + CONFIG_FILE;
+
+    const char* home = getenv("HOME");
+    const char* xdg_home = getenv("XDG_CONFIG_HOME");
+
+    if (!home) {
+        return defaultConfig;
+    }
+
+    // Try ~/.projectM/config.inp
+    QString userConfig = QString(home) + "/.projectM/config.inp";
+    if (QFileInfo::exists(userConfig)) {
+        return userConfig;
+    }
+
+    // Try $XDG_CONFIG_HOME/projectM/config.inp (defaults to ~/.config per XDG spec)
+    QString xdgConfigHome = xdg_home ? QString(xdg_home) : QString(home) + "/.config";
+    {
+        QString xdgConfig = xdgConfigHome + "/projectM/config.inp";
+        if (QFileInfo::exists(xdgConfig)) {
+            return xdgConfig;
+        }
+    }
+
+    // Try to create user config by copying default
+    QString configDir = xdgConfigHome + "/projectM";
+
+    QDir().mkpath(configDir);
+    QString newConfig = configDir + "/config.inp";
+
+    if (QFile::exists(defaultConfig)) {
+        if (QFile::copy(defaultConfig, newConfig)) {
+            return newConfig;
+        }
+    }
+
+    // Fall back to default config
+    if (QFile::exists(defaultConfig)) {
+        return defaultConfig;
+    }
+
+    // No config found -- projectM will use built-in defaults
+    qWarning() << "No projectM config file found, using built-in defaults";
+    return QString();
+}

--- a/src/common/configutil.hpp
+++ b/src/common/configutil.hpp
@@ -1,0 +1,39 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#ifndef CONFIGUTIL_HPP
+#define CONFIGUTIL_HPP
+
+#include <QString>
+
+/**
+ * Locates and returns the path to the projectM configuration file.
+ *
+ * Search order:
+ *   1. ~/.projectM/config.inp
+ *   2. $XDG_CONFIG_HOME/projectM/config.inp  (defaults to ~/.config)
+ *   3. Copies the installed default config into the XDG location
+ *   4. Falls back to the installed default config
+ *   5. Returns an empty QString if nothing is found (projectM uses built-in defaults)
+ */
+QString readProjectMConfig(const QString &installPrefix);
+
+#endif // CONFIGUTIL_HPP

--- a/src/ui-jack/QJackBackend.cpp
+++ b/src/ui-jack/QJackBackend.cpp
@@ -47,7 +47,10 @@ bool QJackBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
     Q_UNUSED(audioMutex);
 
     if (m_client) {
-        return false; // already running
+        // Already running; reactivate (idempotent for backend caching).
+        m_mainWindow = mainWindow;
+        m_active = true;
+        return true;
     }
 
     m_mainWindow = mainWindow;

--- a/src/ui-jack/QJackBackend.cpp
+++ b/src/ui-jack/QJackBackend.cpp
@@ -1,0 +1,190 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "QJackBackend.hpp"
+#include "qprojectm_mainwindow.hpp"
+
+#include <QtDebug>
+#include <cstdlib>
+#include <cstdio>
+
+QJackBackend::QJackBackend(QObject *parent)
+    : QAudioBackend(parent)
+    , m_client(nullptr)
+    , m_inputPort(nullptr)
+    , m_mainWindow(nullptr)
+{
+}
+
+QJackBackend::~QJackBackend()
+{
+    stop();
+}
+
+bool QJackBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
+{
+    Q_UNUSED(audioMutex);
+
+    if (m_client) {
+        return false; // already running
+    }
+
+    m_mainWindow = mainWindow;
+
+    // Open a client connection to the JACK server
+    jack_status_t status;
+    m_client = jack_client_open("projectM", JackNullOption, &status, nullptr);
+    if (!m_client) {
+        qCritical() << "jack_client_open() failed, status =" << status;
+        emit errorOccurred(QStringLiteral("Failed to connect to JACK server"));
+        return false;
+    }
+
+    if (status & JackNameNotUnique) {
+        qDebug() << "JACK: unique name assigned:" << jack_get_client_name(m_client);
+    }
+
+    // Set the process callback -- JACK calls this from its own realtime thread
+    if (jack_set_process_callback(m_client, processCallback, this)) {
+        qCritical() << "Failed to set JACK process callback";
+        jack_client_close(m_client);
+        m_client = nullptr;
+        emit errorOccurred(QStringLiteral("Failed to set JACK process callback"));
+        return false;
+    }
+
+    // Register a shutdown callback
+    jack_on_shutdown(m_client, shutdownCallback, this);
+
+    qDebug() << "JACK engine sample rate:" << jack_get_sample_rate(m_client);
+
+    // Register the input port
+    m_inputPort = jack_port_register(m_client, "input",
+                                     JACK_DEFAULT_AUDIO_TYPE,
+                                     JackPortIsInput, 0);
+    if (!m_inputPort) {
+        qCritical() << "No more JACK ports available";
+        jack_client_close(m_client);
+        m_client = nullptr;
+        emit errorOccurred(QStringLiteral("Failed to register JACK input port"));
+        return false;
+    }
+
+    // Activate the client -- the process callback starts running
+    if (jack_activate(m_client)) {
+        qCritical() << "Cannot activate JACK client";
+        jack_client_close(m_client);
+        m_client = nullptr;
+        m_inputPort = nullptr;
+        emit errorOccurred(QStringLiteral("Failed to activate JACK client"));
+        return false;
+    }
+
+    // Enumerate all output ports and connect them to our input
+    const char **ports = jack_get_ports(m_client, nullptr, nullptr, JackPortIsOutput);
+    if (ports) {
+        for (int i = 0; ports[i] != nullptr; ++i) {
+            qDebug() << "Connecting to JACK port" << ports[i];
+            if (jack_connect(m_client, ports[i], jack_port_name(m_inputPort))) {
+                qWarning() << "Cannot connect JACK port" << ports[i];
+            }
+        }
+        jack_free(ports);
+    } else {
+        qWarning() << "No physical capture ports found in JACK";
+    }
+
+    return true;
+}
+
+void QJackBackend::stop()
+{
+    if (!m_client) {
+        return;
+    }
+
+    jack_deactivate(m_client);
+    jack_client_close(m_client);
+    m_client = nullptr;
+    m_inputPort = nullptr;
+}
+
+int QJackBackend::processCallback(jack_nframes_t nframes, void *arg)
+{
+    QJackBackend *self = static_cast<QJackBackend *>(arg);
+
+    jack_default_audio_sample_t *in =
+        static_cast<jack_default_audio_sample_t *>(
+            jack_port_get_buffer(self->m_inputPort, nframes));
+
+    if (in && self->m_mainWindow) {
+        self->m_mainWindow->addPCM(in, nframes);
+    }
+
+    return 0;
+}
+
+void QJackBackend::shutdownCallback(void *arg)
+{
+    Q_UNUSED(arg);
+    qWarning() << "JACK server shut down";
+}
+
+QString QJackBackend::backendName() const
+{
+    return QStringLiteral("JACK");
+}
+
+QList<QAudioBackend::DeviceInfo> QJackBackend::devices() const
+{
+    QList<DeviceInfo> result;
+    DeviceInfo info;
+    info.id = QStringLiteral("jack-auto");
+    info.displayName = QStringLiteral("JACK (all ports, auto-connect)");
+    result.append(info);
+    return result;
+}
+
+QString QJackBackend::currentDeviceId() const
+{
+    return QStringLiteral("jack-auto");
+}
+
+bool QJackBackend::supportsDeviceSwitching() const
+{
+    return false;
+}
+
+void QJackBackend::selectDevice(const QString &deviceId)
+{
+    Q_UNUSED(deviceId);
+    // JACK auto-connects to all output ports; device selection is a no-op.
+}
+
+void QJackBackend::writeSettings()
+{
+    // No persistent settings for JACK backend.
+}
+
+void QJackBackend::readSettings()
+{
+    // No persistent settings for JACK backend.
+}

--- a/src/ui-jack/QJackBackend.cpp
+++ b/src/ui-jack/QJackBackend.cpp
@@ -23,11 +23,13 @@
 #include "qprojectm_mainwindow.hpp"
 
 #include <QtDebug>
-#include <QThread>
-#include <QEventLoop>
-#include <QTimer>
+#include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstdio>
+#include <memory>
+#include <mutex>
+#include <thread>
 
 QJackBackend::QJackBackend(QObject *parent)
     : QAudioBackend(parent)
@@ -59,31 +61,65 @@ bool QJackBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
     // Run in a worker thread with a timeout — jack_client_open can block
     // for several seconds even with JackNoStartServer if the server socket
     // exists but is unresponsive.
-    jack_client_t *result = nullptr;
-    jack_status_t status = JackFailure;
+    //
+    // The state is heap-allocated and shared with the worker so it outlives
+    // a timeout. On timeout we mark the call as abandoned and detach the
+    // thread; if the call eventually returns a valid client, the worker
+    // closes it itself. This avoids QThread::terminate (async, unsafe) and
+    // dangling references to stack variables.
+    struct OpenState {
+        std::mutex mutex;
+        std::condition_variable cv;
+        jack_client_t *client = nullptr;
+        jack_status_t status = JackFailure;
+        bool done = false;
+        bool abandoned = false;
+    };
 
-    QThread *worker = QThread::create([&result, &status]() {
-        result = jack_client_open("projectM", JackNoStartServer, &status, nullptr);
+    auto state = std::make_shared<OpenState>();
+
+    std::thread worker([state]() {
+        jack_status_t localStatus = JackFailure;
+        jack_client_t *result = jack_client_open("projectM", JackNoStartServer, &localStatus, nullptr);
+
+        bool shouldClose = false;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->status = localStatus;
+            if (state->abandoned) {
+                shouldClose = (result != nullptr);
+            } else {
+                state->client = result;
+            }
+            state->done = true;
+        }
+        state->cv.notify_all();
+
+        // Caller gave up before we returned; clean up the orphan client.
+        if (shouldClose) {
+            jack_client_close(result);
+        }
     });
-    worker->start();
-    if (!worker->wait(3000)) { // 3 second timeout
-        qWarning() << "JACK connection timed out";
-        worker->terminate();
-        worker->wait(1000);
-        delete worker;
-        emit errorOccurred(QStringLiteral("JACK server connection timed out"));
-        return false;
-    }
-    delete worker;
+    worker.detach();
 
-    m_client = result;
-    if (!m_client) {
-        qCritical() << "jack_client_open() failed, status =" << status;
-        emit errorOccurred(QStringLiteral("Failed to connect to JACK server"));
-        return false;
+    {
+        std::unique_lock<std::mutex> lock(state->mutex);
+        if (!state->cv.wait_for(lock, std::chrono::seconds(3),
+                                [&]{ return state->done; })) {
+            state->abandoned = true;
+            qWarning() << "JACK connection timed out";
+            emit errorOccurred(QStringLiteral("JACK server connection timed out"));
+            return false;
+        }
+        m_client = state->client;
+        if (!m_client) {
+            qCritical() << "jack_client_open() failed, status =" << state->status;
+            emit errorOccurred(QStringLiteral("Failed to connect to JACK server"));
+            return false;
+        }
     }
 
-    if (status & JackNameNotUnique) {
+    if (state->status & JackNameNotUnique) {
         qDebug() << "JACK: unique name assigned:" << jack_get_client_name(m_client);
     }
 

--- a/src/ui-jack/QJackBackend.cpp
+++ b/src/ui-jack/QJackBackend.cpp
@@ -51,7 +51,7 @@ bool QJackBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
 
     // Open a client connection to the JACK server
     jack_status_t status;
-    m_client = jack_client_open("projectM", JackNullOption, &status, nullptr);
+    m_client = jack_client_open("projectM", JackNoStartServer, &status, nullptr);
     if (!m_client) {
         qCritical() << "jack_client_open() failed, status =" << status;
         emit errorOccurred(QStringLiteral("Failed to connect to JACK server"));

--- a/src/ui-jack/QJackBackend.cpp
+++ b/src/ui-jack/QJackBackend.cpp
@@ -23,6 +23,9 @@
 #include "qprojectm_mainwindow.hpp"
 
 #include <QtDebug>
+#include <QThread>
+#include <QEventLoop>
+#include <QTimer>
 #include <cstdlib>
 #include <cstdio>
 
@@ -49,9 +52,28 @@ bool QJackBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
 
     m_mainWindow = mainWindow;
 
-    // Open a client connection to the JACK server
-    jack_status_t status;
-    m_client = jack_client_open("projectM", JackNoStartServer, &status, nullptr);
+    // Open a client connection to the JACK server.
+    // Run in a worker thread with a timeout — jack_client_open can block
+    // for several seconds even with JackNoStartServer if the server socket
+    // exists but is unresponsive.
+    jack_client_t *result = nullptr;
+    jack_status_t status = JackFailure;
+
+    QThread *worker = QThread::create([&result, &status]() {
+        result = jack_client_open("projectM", JackNoStartServer, &status, nullptr);
+    });
+    worker->start();
+    if (!worker->wait(3000)) { // 3 second timeout
+        qWarning() << "JACK connection timed out";
+        worker->terminate();
+        worker->wait(1000);
+        delete worker;
+        emit errorOccurred(QStringLiteral("JACK server connection timed out"));
+        return false;
+    }
+    delete worker;
+
+    m_client = result;
     if (!m_client) {
         qCritical() << "jack_client_open() failed, status =" << status;
         emit errorOccurred(QStringLiteral("Failed to connect to JACK server"));

--- a/src/ui-jack/QJackBackend.hpp
+++ b/src/ui-jack/QJackBackend.hpp
@@ -1,0 +1,61 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#ifndef QJACK_BACKEND_HPP
+#define QJACK_BACKEND_HPP
+
+#include "QAudioBackend.hpp"
+
+#include <jack/jack.h>
+
+class QJackBackend : public QAudioBackend
+{
+    Q_OBJECT
+
+public:
+    explicit QJackBackend(QObject *parent = nullptr);
+    virtual ~QJackBackend();
+
+    bool start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex) override;
+    void stop() override;
+
+    QString backendName() const override;
+
+    QList<DeviceInfo> devices() const override;
+    QString currentDeviceId() const override;
+    bool supportsDeviceSwitching() const override;
+
+    void writeSettings() override;
+    void readSettings() override;
+
+public slots:
+    void selectDevice(const QString &deviceId) override;
+
+private:
+    static int processCallback(jack_nframes_t nframes, void *arg);
+    static void shutdownCallback(void *arg);
+
+    jack_client_t *m_client;
+    jack_port_t *m_inputPort;
+    QProjectM_MainWindow *m_mainWindow;
+};
+
+#endif // QJACK_BACKEND_HPP

--- a/src/ui-pipewire/QPipeWireBackend.cpp
+++ b/src/ui-pipewire/QPipeWireBackend.cpp
@@ -54,6 +54,7 @@ bool QPipeWireBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMute
             this, &QPipeWireBackend::activeDeviceChanged);
 
     m_thread->start();
+    m_active = true;
     return true;
 }
 

--- a/src/ui-pipewire/QPipeWireBackend.cpp
+++ b/src/ui-pipewire/QPipeWireBackend.cpp
@@ -36,7 +36,16 @@ QPipeWireBackend::QPipeWireBackend(QObject *parent)
 
 QPipeWireBackend::~QPipeWireBackend()
 {
-    stop();
+    // Real teardown happens here at process exit, not on stop() — stop()
+    // only deactivates audio because PipeWire can't be safely re-initialized
+    // within the same process.
+    if (m_thread) {
+        QPipeWireThread::setAudioActive(false);
+        m_thread->writeSettings();
+        m_thread->cleanup(); // quits main loop, waits for thread, destroys PW resources
+        delete m_thread;
+        m_thread = nullptr;
+    }
 }
 
 bool QPipeWireBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)

--- a/src/ui-pipewire/QPipeWireBackend.cpp
+++ b/src/ui-pipewire/QPipeWireBackend.cpp
@@ -42,13 +42,11 @@ QPipeWireBackend::~QPipeWireBackend()
 bool QPipeWireBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
 {
     if (m_thread) {
-        return false; // already running
+        return true; // already running, reuse
     }
 
     m_mainWindow = mainWindow;
 
-    // QPipeWireThread requires argc/argv; pass 0/nullptr since the unified main
-    // handles argument parsing before the backend is created.
     QPipeWireThread::setAudioMutex(audioMutex);
     m_thread = new QPipeWireThread(m_argc, m_argv, mainWindow);
 
@@ -61,14 +59,9 @@ bool QPipeWireBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMute
 
 void QPipeWireBackend::stop()
 {
-    if (!m_thread) {
-        return;
-    }
-
-    m_thread->writeSettings();
-    m_thread->cleanup();
-    delete m_thread;
-    m_thread = nullptr;
+    // Keep the thread alive — PipeWire cannot be re-initialized after
+    // cleanup within the same process. The thread stays running but
+    // audio just isn't consumed while another backend is active.
 }
 
 QString QPipeWireBackend::backendName() const

--- a/src/ui-pipewire/QPipeWireBackend.cpp
+++ b/src/ui-pipewire/QPipeWireBackend.cpp
@@ -1,0 +1,125 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "QPipeWireBackend.hpp"
+#include "QPipeWireThread.hpp"
+
+#include <QMutex>
+#include <QHashIterator>
+
+QPipeWireBackend::QPipeWireBackend(QObject *parent)
+    : QAudioBackend(parent)
+    , m_thread(nullptr)
+    , m_mainWindow(nullptr)
+    , m_argc(0)
+{
+    m_argv[0] = nullptr;
+}
+
+QPipeWireBackend::~QPipeWireBackend()
+{
+    stop();
+}
+
+bool QPipeWireBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
+{
+    if (m_thread) {
+        return false; // already running
+    }
+
+    m_mainWindow = mainWindow;
+
+    // QPipeWireThread requires argc/argv; pass 0/nullptr since the unified main
+    // handles argument parsing before the backend is created.
+    QPipeWireThread::setAudioMutex(audioMutex);
+    m_thread = new QPipeWireThread(m_argc, m_argv, mainWindow);
+
+    connect(m_thread, &QPipeWireThread::deviceChanged,
+            this, &QPipeWireBackend::activeDeviceChanged);
+
+    m_thread->start();
+    return true;
+}
+
+void QPipeWireBackend::stop()
+{
+    if (!m_thread) {
+        return;
+    }
+
+    m_thread->writeSettings();
+    m_thread->cleanup();
+    delete m_thread;
+    m_thread = nullptr;
+}
+
+QString QPipeWireBackend::backendName() const
+{
+    return QStringLiteral("PipeWire");
+}
+
+QList<QAudioBackend::DeviceInfo> QPipeWireBackend::devices() const
+{
+    QList<DeviceInfo> result;
+    const QHash<uint32_t, QString> &sources = QPipeWireThread::sourceList();
+
+    QHashIterator<uint32_t, QString> it(sources);
+    while (it.hasNext()) {
+        it.next();
+        DeviceInfo info;
+        info.id = QString::number(it.key());
+        info.displayName = it.value();
+        result.append(info);
+    }
+
+    return result;
+}
+
+QString QPipeWireBackend::currentDeviceId() const
+{
+    return QString::number(QPipeWireThread::currentNodeId());
+}
+
+bool QPipeWireBackend::supportsDeviceSwitching() const
+{
+    return true;
+}
+
+void QPipeWireBackend::selectDevice(const QString &deviceId)
+{
+    if (m_thread) {
+        m_thread->connectDeviceById(deviceId.toUInt());
+    }
+}
+
+void QPipeWireBackend::writeSettings()
+{
+    if (m_thread) {
+        m_thread->writeSettings();
+    }
+}
+
+void QPipeWireBackend::readSettings()
+{
+    if (m_thread) {
+        m_thread->readSettings();
+    }
+}

--- a/src/ui-pipewire/QPipeWireBackend.cpp
+++ b/src/ui-pipewire/QPipeWireBackend.cpp
@@ -55,14 +55,18 @@ bool QPipeWireBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMute
 
     m_thread->start();
     m_active = true;
+    QPipeWireThread::setAudioActive(true);
     return true;
 }
 
 void QPipeWireBackend::stop()
 {
     // Keep the thread alive — PipeWire cannot be re-initialized after
-    // cleanup within the same process. The thread stays running but
-    // audio just isn't consumed while another backend is active.
+    // cleanup within the same process. Pause audio delivery instead so
+    // samples aren't double-fed through addPCM when another backend
+    // becomes active.
+    m_active = false;
+    QPipeWireThread::setAudioActive(false);
 }
 
 QString QPipeWireBackend::backendName() const

--- a/src/ui-pipewire/QPipeWireBackend.hpp
+++ b/src/ui-pipewire/QPipeWireBackend.hpp
@@ -1,0 +1,59 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#ifndef QPIPEWIRE_BACKEND_HPP
+#define QPIPEWIRE_BACKEND_HPP
+
+#include "QAudioBackend.hpp"
+
+class QPipeWireThread;
+
+class QPipeWireBackend : public QAudioBackend
+{
+    Q_OBJECT
+
+public:
+    explicit QPipeWireBackend(QObject *parent = nullptr);
+    virtual ~QPipeWireBackend();
+
+    bool start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex) override;
+    void stop() override;
+
+    QString backendName() const override;
+
+    QList<DeviceInfo> devices() const override;
+    QString currentDeviceId() const override;
+    bool supportsDeviceSwitching() const override;
+
+    void writeSettings() override;
+    void readSettings() override;
+
+public slots:
+    void selectDevice(const QString &deviceId) override;
+
+private:
+    QPipeWireThread *m_thread;
+    QProjectM_MainWindow *m_mainWindow;
+    int m_argc;
+    char *m_argv[1];
+};
+
+#endif // QPIPEWIRE_BACKEND_HPP

--- a/src/ui-pipewire/QPipeWireThread.cpp
+++ b/src/ui-pipewire/QPipeWireThread.cpp
@@ -31,6 +31,12 @@ QHash<uint32_t, QString> QPipeWireThread::s_sourceList;
 QHash<uint32_t, bool> QPipeWireThread::s_isSinkMap;
 QString QPipeWireThread::s_currentDeviceName;
 uint32_t QPipeWireThread::s_currentNodeId = PW_ID_ANY;
+std::atomic<bool> QPipeWireThread::s_audioActive{true};
+
+void QPipeWireThread::setAudioActive(bool active)
+{
+    s_audioActive.store(active, std::memory_order_release);
+}
 
 QPipeWireThread::QPipeWireThread(int _argc, char **_argv, QProjectM_MainWindow *mainWindow)
     : QThread(nullptr), argc(_argc), argv(_argv), m_qprojectM_MainWindow(mainWindow)
@@ -82,6 +88,14 @@ void QPipeWireThread::on_process(void *userdata)
 
     struct spa_buffer *buf = b->buffer;
     if (buf->datas[0].data == nullptr) {
+        pw_stream_queue_buffer(data->stream, b);
+        return;
+    }
+
+    // Drop audio when this backend isn't the active one (e.g., user switched
+    // to another backend in the unified app). The stream stays connected
+    // because PipeWire can't be re-initialized within the same process.
+    if (!s_audioActive.load(std::memory_order_acquire)) {
         pw_stream_queue_buffer(data->stream, b);
         return;
     }

--- a/src/ui-pipewire/QPipeWireThread.cpp
+++ b/src/ui-pipewire/QPipeWireThread.cpp
@@ -358,12 +358,18 @@ void QPipeWireThread::cleanup()
         s_data.loop = nullptr;
     }
 
-    pw_deinit();
+    // Do not call pw_deinit() here — PipeWire does not support
+    // re-initialization after deinit within the same process.
 }
+
+static bool s_pwInitialized = false;
 
 void QPipeWireThread::run()
 {
-    pw_init(&argc, &argv);
+    if (!s_pwInitialized) {
+        pw_init(&argc, &argv);
+        s_pwInitialized = true;
+    }
 
     s_data.loop = pw_main_loop_new(nullptr);
     s_data.mainWindow = m_qprojectM_MainWindow;

--- a/src/ui-pipewire/QPipeWireThread.cpp
+++ b/src/ui-pipewire/QPipeWireThread.cpp
@@ -371,6 +371,13 @@ void QPipeWireThread::run()
         s_pwInitialized = true;
     }
 
+    // Reset all static state for clean re-initialization
+    memset(&s_data, 0, sizeof(s_data));
+    s_sourceList.clear();
+    s_isSinkMap.clear();
+    s_currentNodeId = PW_ID_ANY;
+    s_currentDeviceName.clear();
+
     s_data.loop = pw_main_loop_new(nullptr);
     s_data.mainWindow = m_qprojectM_MainWindow;
     s_data.audioMutex = s_audioMutex;

--- a/src/ui-pipewire/QPipeWireThread.hpp
+++ b/src/ui-pipewire/QPipeWireThread.hpp
@@ -29,6 +29,8 @@
 #include <QMutex>
 #include <QtDebug>
 
+#include <atomic>
+
 #include <pipewire/pipewire.h>
 #include <spa/param/audio/format-utils.h>
 
@@ -49,6 +51,11 @@ public:
     static void setAudioMutex(QMutex *mutex) { s_audioMutex = mutex; }
     void writeSettings();
     void readSettings();
+
+    // Pause/resume audio delivery without tearing down the PipeWire stream.
+    // Used by the unified backend to switch audio sources without re-initializing
+    // PipeWire (which is unsafe within a single process).
+    static void setAudioActive(bool active);
 
     // Device enumeration
     static const QHash<uint32_t, QString>& sourceList() { return s_sourceList; }
@@ -100,6 +107,7 @@ private:
     QProjectM_MainWindow *m_qprojectM_MainWindow;
     static QMutex *s_audioMutex;
     static AudioData s_data;
+    static std::atomic<bool> s_audioActive;
 
     static struct pw_context *s_context;
 

--- a/src/ui-pulseaudio/QPulseAudioBackend.cpp
+++ b/src/ui-pulseaudio/QPulseAudioBackend.cpp
@@ -37,7 +37,17 @@ QPulseAudioBackend::QPulseAudioBackend(QObject *parent)
 
 QPulseAudioBackend::~QPulseAudioBackend()
 {
-    stop();
+    // Real teardown happens here at process exit, not on stop() — stop()
+    // only deactivates audio because PulseAudio re-init within the same
+    // process is unreliable.
+    if (m_thread) {
+        QPulseAudioThread::setAudioActive(false);
+        m_thread->writeSettings();
+        m_thread->cleanup();      // signals PA mainloop to stop
+        m_thread->wait(3000);      // wait up to 3s for run() to exit
+        delete m_thread;
+        m_thread = nullptr;
+    }
 }
 
 bool QPulseAudioBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)

--- a/src/ui-pulseaudio/QPulseAudioBackend.cpp
+++ b/src/ui-pulseaudio/QPulseAudioBackend.cpp
@@ -24,7 +24,6 @@
 
 #include <QMutex>
 #include <QModelIndex>
-#include <QStandardItemModel>
 #include <QList>
 #include <algorithm>
 
@@ -134,13 +133,6 @@ void QPulseAudioBackend::selectDevice(const QString &deviceId)
         return;
     }
 
-    // QPulseAudioThread::connectDevice() uses index.row() as the key for
-    // s_sourceList.find(index.row()).  We need to produce a QModelIndex whose
-    // row() equals the PulseAudio source index (the int key in the hash).
-    //
-    // QModelIndex can only be created via a model.  We use a temporary
-    // QStandardItemModel with enough rows to cover the target key value, then
-    // pull out the index at the right row.
     int targetKey = deviceId.toInt();
     const QPulseAudioThread::SourceContainer &sources = m_thread->devices();
 
@@ -148,11 +140,7 @@ void QPulseAudioBackend::selectDevice(const QString &deviceId)
         return;
     }
 
-    // Create a temporary model large enough to produce a valid index at
-    // row == targetKey.
-    QStandardItemModel tmpModel(targetKey + 1, 1);
-    QModelIndex idx = tmpModel.index(targetKey, 0);
-    m_thread->connectDevice(idx);
+    m_thread->connectDeviceById(targetKey);
 }
 
 void QPulseAudioBackend::writeSettings()

--- a/src/ui-pulseaudio/QPulseAudioBackend.cpp
+++ b/src/ui-pulseaudio/QPulseAudioBackend.cpp
@@ -58,14 +58,18 @@ bool QPulseAudioBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMu
             this, &QPulseAudioBackend::activeDeviceChanged);
 
     m_thread->start();
+    m_active = true;
+    QPulseAudioThread::setAudioActive(true);
     return true;
 }
 
 void QPulseAudioBackend::stop()
 {
-    // Keep the thread alive — PulseAudio has similar re-init issues.
-    // The thread stays running but audio isn't consumed while another
-    // backend is active.
+    // Keep the thread alive — PulseAudio re-init within the same process
+    // is unreliable. Pause audio delivery so samples don't double-feed
+    // through addPCM when another backend becomes active.
+    m_active = false;
+    QPulseAudioThread::setAudioActive(false);
 }
 
 QString QPulseAudioBackend::backendName() const

--- a/src/ui-pulseaudio/QPulseAudioBackend.cpp
+++ b/src/ui-pulseaudio/QPulseAudioBackend.cpp
@@ -45,7 +45,7 @@ bool QPulseAudioBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMu
     Q_UNUSED(audioMutex);
 
     if (m_thread) {
-        return false; // already running
+        return true; // already running, reuse
     }
 
     m_mainWindow = mainWindow;
@@ -63,14 +63,9 @@ bool QPulseAudioBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMu
 
 void QPulseAudioBackend::stop()
 {
-    if (!m_thread) {
-        return;
-    }
-
-    m_thread->writeSettings();
-    m_thread->cleanup();
-    delete m_thread;
-    m_thread = nullptr;
+    // Keep the thread alive — PulseAudio has similar re-init issues.
+    // The thread stays running but audio isn't consumed while another
+    // backend is active.
 }
 
 QString QPulseAudioBackend::backendName() const

--- a/src/ui-pulseaudio/QPulseAudioBackend.cpp
+++ b/src/ui-pulseaudio/QPulseAudioBackend.cpp
@@ -1,0 +1,160 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "QPulseAudioBackend.hpp"
+#include "QPulseAudioThread.hpp"
+
+#include <QMutex>
+#include <QModelIndex>
+#include <QStandardItemModel>
+#include <QList>
+#include <algorithm>
+
+QPulseAudioBackend::QPulseAudioBackend(QObject *parent)
+    : QAudioBackend(parent)
+    , m_thread(nullptr)
+    , m_mainWindow(nullptr)
+{
+}
+
+QPulseAudioBackend::~QPulseAudioBackend()
+{
+    stop();
+}
+
+bool QPulseAudioBackend::start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex)
+{
+    Q_UNUSED(audioMutex);
+
+    if (m_thread) {
+        return false; // already running
+    }
+
+    m_mainWindow = mainWindow;
+
+    // QPulseAudioThread requires argc/argv; pass 0/nullptr since the unified
+    // main handles argument parsing before the backend is created.
+    m_thread = new QPulseAudioThread(0, nullptr, mainWindow);
+
+    connect(m_thread, &QPulseAudioThread::deviceChanged,
+            this, &QPulseAudioBackend::activeDeviceChanged);
+
+    m_thread->start();
+    return true;
+}
+
+void QPulseAudioBackend::stop()
+{
+    if (!m_thread) {
+        return;
+    }
+
+    m_thread->writeSettings();
+    m_thread->cleanup();
+    delete m_thread;
+    m_thread = nullptr;
+}
+
+QString QPulseAudioBackend::backendName() const
+{
+    return QStringLiteral("PulseAudio");
+}
+
+QList<QAudioBackend::DeviceInfo> QPulseAudioBackend::devices() const
+{
+    QList<DeviceInfo> result;
+
+    if (!m_thread) {
+        return result;
+    }
+
+    const QPulseAudioThread::SourceContainer &sources = m_thread->devices();
+    QPulseAudioThread::SourceContainer::const_iterator it;
+    for (it = sources.constBegin(); it != sources.constEnd(); ++it) {
+        DeviceInfo info;
+        info.id = QString::number(it.key());
+        info.displayName = it.value();
+        result.append(info);
+    }
+
+    return result;
+}
+
+QString QPulseAudioBackend::currentDeviceId() const
+{
+    if (!m_thread) {
+        return QString();
+    }
+
+    QPulseAudioThread::SourceContainer::const_iterator pos = m_thread->sourcePosition();
+    const QPulseAudioThread::SourceContainer &sources = m_thread->devices();
+
+    if (pos != sources.constEnd()) {
+        return QString::number(pos.key());
+    }
+
+    return QString();
+}
+
+bool QPulseAudioBackend::supportsDeviceSwitching() const
+{
+    return true;
+}
+
+void QPulseAudioBackend::selectDevice(const QString &deviceId)
+{
+    if (!m_thread) {
+        return;
+    }
+
+    // QPulseAudioThread::connectDevice() uses index.row() as the key for
+    // s_sourceList.find(index.row()).  We need to produce a QModelIndex whose
+    // row() equals the PulseAudio source index (the int key in the hash).
+    //
+    // QModelIndex can only be created via a model.  We use a temporary
+    // QStandardItemModel with enough rows to cover the target key value, then
+    // pull out the index at the right row.
+    int targetKey = deviceId.toInt();
+    const QPulseAudioThread::SourceContainer &sources = m_thread->devices();
+
+    if (!sources.contains(targetKey)) {
+        return;
+    }
+
+    // Create a temporary model large enough to produce a valid index at
+    // row == targetKey.
+    QStandardItemModel tmpModel(targetKey + 1, 1);
+    QModelIndex idx = tmpModel.index(targetKey, 0);
+    m_thread->connectDevice(idx);
+}
+
+void QPulseAudioBackend::writeSettings()
+{
+    if (m_thread) {
+        m_thread->writeSettings();
+    }
+}
+
+void QPulseAudioBackend::readSettings()
+{
+    // PulseAudio readSettings is a private static method on the thread;
+    // it is called internally during initialization.
+}

--- a/src/ui-pulseaudio/QPulseAudioBackend.hpp
+++ b/src/ui-pulseaudio/QPulseAudioBackend.hpp
@@ -1,0 +1,57 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#ifndef QPULSEAUDIO_BACKEND_HPP
+#define QPULSEAUDIO_BACKEND_HPP
+
+#include "QAudioBackend.hpp"
+
+class QPulseAudioThread;
+
+class QPulseAudioBackend : public QAudioBackend
+{
+    Q_OBJECT
+
+public:
+    explicit QPulseAudioBackend(QObject *parent = nullptr);
+    virtual ~QPulseAudioBackend();
+
+    bool start(QProjectM_MainWindow *mainWindow, QMutex *audioMutex) override;
+    void stop() override;
+
+    QString backendName() const override;
+
+    QList<DeviceInfo> devices() const override;
+    QString currentDeviceId() const override;
+    bool supportsDeviceSwitching() const override;
+
+    void writeSettings() override;
+    void readSettings() override;
+
+public slots:
+    void selectDevice(const QString &deviceId) override;
+
+private:
+    QPulseAudioThread *m_thread;
+    QProjectM_MainWindow *m_mainWindow;
+};
+
+#endif // QPULSEAUDIO_BACKEND_HPP

--- a/src/ui-pulseaudio/QPulseAudioThread.cpp
+++ b/src/ui-pulseaudio/QPulseAudioThread.cpp
@@ -204,13 +204,19 @@ QPulseAudioThread::SourceContainer::const_iterator QPulseAudioThread::scanForPla
 }
 
 void QPulseAudioThread::connectDevice ( const QModelIndex & index )
-{	
-	
+{
+
 	if (index.isValid())
 		reconnect(s_sourceList.find(index.row()));
 	else
 		reconnect(s_sourceList.end());
-	
+
+	emit(deviceChanged());
+}
+
+void QPulseAudioThread::connectDeviceById(int sourceId)
+{
+	reconnect(s_sourceList.find(sourceId));
 	emit(deviceChanged());
 }
 

--- a/src/ui-pulseaudio/QPulseAudioThread.cpp
+++ b/src/ui-pulseaudio/QPulseAudioThread.cpp
@@ -103,9 +103,21 @@ QPulseAudioThread::SourceContainer::const_iterator QPulseAudioThread::readSettin
 	return s_sourceList.end();
 }
 
+void QPulseAudioThread::writeSettings()
+{
+	QSettings settings("projectM", "qprojectM-pulseaudio");
+
+	if (s_sourcePosition != s_sourceList.end()) {
+		settings.setValue("tryFirstAvailablePlaybackMonitor", false);
+		settings.setValue("pulseAudioDeviceName", *s_sourcePosition);
+	} else {
+		settings.setValue("tryFirstAvailablePlaybackMonitor", true);
+	}
+}
+
 void QPulseAudioThread::cleanup()
 {
-	
+
 	pa_threaded_mainloop_stop ( mainloop );
 
 	if ( stream )

--- a/src/ui-pulseaudio/QPulseAudioThread.cpp
+++ b/src/ui-pulseaudio/QPulseAudioThread.cpp
@@ -60,7 +60,13 @@
 
 QPulseAudioThread::SourceContainer QPulseAudioThread::s_sourceList;
 QPulseAudioThread::SourceContainer::const_iterator QPulseAudioThread::s_sourcePosition;
- 
+std::atomic<bool> QPulseAudioThread::s_audioActive{true};
+
+void QPulseAudioThread::setAudioActive(bool active)
+{
+    s_audioActive.store(active, std::memory_order_release);
+}
+
 QProjectM_MainWindow ** QPulseAudioThread::s_qprojectM_MainWindowPtr = 0;
  
 QPulseAudioThread::QPulseAudioThread ( int _argc, char **_argv, QProjectM_MainWindow * mainWindow ) : QThread ( 0 ), argc ( _argc ), argv ( _argv ),  m_qprojectM_MainWindow (mainWindow)
@@ -349,11 +355,14 @@ void QPulseAudioThread::stream_read_callback ( pa_stream *s, size_t length, void
 		return;
 	}
 
-	(*s_qprojectM_MainWindowPtr)->addPCM( (float*)data, length / ( sizeof ( float ) ) );
-	
-	
-	//buffer = ( float* ) pa_xmalloc ( buffer_length = length );
-	//memcpy ( buffer, data, length );
+	// Drop audio when this backend isn't the active one (e.g., user switched
+	// to another backend in the unified app). Stream stays connected because
+	// PulseAudio re-init within the same process is unreliable.
+	if (s_audioActive.load(std::memory_order_acquire))
+	{
+		(*s_qprojectM_MainWindowPtr)->addPCM( (float*)data, length / ( sizeof ( float ) ) );
+	}
+
 	buffer_index = 0;
 	pa_stream_drop ( s );
 }

--- a/src/ui-pulseaudio/QPulseAudioThread.hpp
+++ b/src/ui-pulseaudio/QPulseAudioThread.hpp
@@ -80,6 +80,11 @@ class QPulseAudioThread : public QThread
 
 		void connectDevice(const QModelIndex & index = QModelIndex());
 
+		// Connect by PulseAudio source index directly. Avoids the
+		// QStandardItemModel-just-to-make-an-index dance for callers that
+		// already know the source id.
+		void connectDeviceById(int sourceId);
+
 	signals:
 		void deviceChanged();
 		void threadCleanedUp();

--- a/src/ui-pulseaudio/QPulseAudioThread.hpp
+++ b/src/ui-pulseaudio/QPulseAudioThread.hpp
@@ -30,6 +30,8 @@
 #include <QtDebug>
 #include <QMutex>
 
+#include <atomic>
+
 extern "C"
 {
 #include <pulse/introspect.h>
@@ -56,6 +58,11 @@ class QPulseAudioThread : public QThread
 			return s_sourceList;
 		}
 		void writeSettings();
+
+		// Pause/resume audio delivery without disconnecting the stream.
+		// Used by the unified backend to switch audio sources without
+		// destroying state.
+		static void setAudioActive(bool active);
 
 		inline const SourceContainer::const_iterator & sourcePosition() {
 			return s_sourcePosition;
@@ -105,6 +112,7 @@ class QPulseAudioThread : public QThread
 		static QMutex * s_audioMutex;
 		static SourceContainer s_sourceList;
 		static SourceContainer::const_iterator s_sourcePosition;
+		static std::atomic<bool> s_audioActive;
 		int argc;
 		char ** argv;
 		QProjectM_MainWindow * m_qprojectM_MainWindow;

--- a/src/ui-unified/CMakeLists.txt
+++ b/src/ui-unified/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(projectM-Qt-Unified
     ${UNIFIED_LINK_LIBS}
     ${PROJECTM_OPENGL_LIBRARIES}
     ${QT_LINK_TARGETS}
+    ${CMAKE_DL_LIBS}
 )
 
 set_target_properties(projectM-Qt-Unified PROPERTIES

--- a/src/ui-unified/CMakeLists.txt
+++ b/src/ui-unified/CMakeLists.txt
@@ -1,0 +1,72 @@
+set(UNIFIED_SOURCES
+    qprojectM-unified.cpp
+)
+
+set(UNIFIED_LINK_LIBS
+    projectM-Qt-Common
+)
+
+set(UNIFIED_INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/src/common
+)
+
+if(ENABLE_PIPEWIRE)
+    list(APPEND UNIFIED_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/ui-pipewire/QPipeWireBackend.cpp
+        ${CMAKE_SOURCE_DIR}/src/ui-pipewire/QPipeWireThread.cpp
+    )
+    list(APPEND UNIFIED_LINK_LIBS PkgConfig::PIPEWIRE)
+    list(APPEND UNIFIED_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/ui-pipewire)
+endif()
+
+if(ENABLE_PULSEAUDIO)
+    list(APPEND UNIFIED_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/ui-pulseaudio/QPulseAudioBackend.cpp
+        ${CMAKE_SOURCE_DIR}/src/ui-pulseaudio/QPulseAudioThread.cpp
+    )
+    list(APPEND UNIFIED_LINK_LIBS Pulseaudio::Pulseaudio)
+    list(APPEND UNIFIED_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/ui-pulseaudio)
+endif()
+
+if(ENABLE_JACK)
+    list(APPEND UNIFIED_SOURCES
+        ${CMAKE_SOURCE_DIR}/src/ui-jack/QJackBackend.cpp
+    )
+    list(APPEND UNIFIED_LINK_LIBS JACK::JACK)
+    list(APPEND UNIFIED_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/ui-jack)
+endif()
+
+add_executable(projectM-Qt-Unified ${UNIFIED_SOURCES})
+
+target_compile_definitions(projectM-Qt-Unified
+    PRIVATE
+    PROJECTM_PREFIX="${CMAKE_INSTALL_PREFIX}"
+)
+
+if(ENABLE_PIPEWIRE)
+    target_compile_definitions(projectM-Qt-Unified PRIVATE ENABLE_PIPEWIRE)
+endif()
+if(ENABLE_PULSEAUDIO)
+    target_compile_definitions(projectM-Qt-Unified PRIVATE ENABLE_PULSEAUDIO)
+endif()
+if(ENABLE_JACK)
+    target_compile_definitions(projectM-Qt-Unified PRIVATE ENABLE_JACK)
+endif()
+
+target_include_directories(projectM-Qt-Unified PRIVATE ${UNIFIED_INCLUDE_DIRS})
+
+target_link_libraries(projectM-Qt-Unified
+    PRIVATE
+    ${UNIFIED_LINK_LIBS}
+    ${PROJECTM_OPENGL_LIBRARIES}
+    ${QT_LINK_TARGETS}
+)
+
+set_target_properties(projectM-Qt-Unified PROPERTIES
+    OUTPUT_NAME projectM-qt
+)
+
+install(TARGETS projectM-Qt-Unified
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT Applications
+)

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -160,12 +160,13 @@ int main(int argc, char *argv[])
     QMutex audioMutex;
     QProjectM_MainWindow *mainWindow = new QProjectM_MainWindow(config_file, &audioMutex);
 
-    // -- Build the audio backend menu --
+    // -- Add backend submenu under Settings --
+    QMenu *settingsMenu = mainWindow->findChild<QMenu*>("menuSettings");
     QMenu *audioMenu = new QMenu("Audio Backend", mainWindow);
     QActionGroup *backendGroup = new QActionGroup(mainWindow);
     backendGroup->setExclusive(true);
 
-    // Device settings action (registered with main window's settings menu)
+    // Device settings action
     devAction = new QAction("Audio device settings...", mainWindow);
     mainWindow->registerSettingsAction(devAction);
 
@@ -228,8 +229,11 @@ int main(int argc, char *argv[])
         audioMenu->addAction(action);
     }
 
-    // Add menu to menu bar
-    mainWindow->menuBar()->addMenu(audioMenu);
+    // Add backend submenu to Settings menu
+    if (settingsMenu) {
+        settingsMenu->addSeparator();
+        settingsMenu->addMenu(audioMenu);
+    }
 
     mainWindow->setAttribute(Qt::WA_ShowWithoutActivating, false);
     mainWindow->setWindowState(Qt::WindowNoState);

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -26,6 +26,9 @@
 
 #include <QApplication>
 #include <QAction>
+#include <QActionGroup>
+#include <QMenu>
+#include <QMenuBar>
 #include <QMutex>
 #include <QSettings>
 #include <QSurfaceFormat>
@@ -64,8 +67,6 @@ public:
 
 static QString autoDetectBackend()
 {
-    // Prefer PipeWire > PulseAudio > JACK based on what was compiled in.
-    // Actual server availability is checked when the backend starts.
 #ifdef ENABLE_PIPEWIRE
     return "pipewire";
 #elif defined(ENABLE_PULSEAUDIO)
@@ -91,9 +92,29 @@ static QAudioBackend* createBackend(const QString &name)
     return nullptr;
 }
 
+struct BackendEntry {
+    QString id;
+    QString label;
+};
+
+static QList<BackendEntry> availableBackends()
+{
+    QList<BackendEntry> list;
+    BackendEntry e;
+#ifdef ENABLE_PIPEWIRE
+    e.id = "pipewire"; e.label = "PipeWire"; list.append(e);
+#endif
+#ifdef ENABLE_PULSEAUDIO
+    e.id = "pulseaudio"; e.label = "PulseAudio"; list.append(e);
+#endif
+#ifdef ENABLE_JACK
+    e.id = "jack"; e.label = "JACK"; list.append(e);
+#endif
+    return list;
+}
+
 int main(int argc, char *argv[])
 {
-    // Set default OpenGL surface format before creating QApplication
     QSurfaceFormat format;
     format.setRenderableType(QSurfaceFormat::OpenGL);
     format.setVersion(3, 3);
@@ -106,7 +127,7 @@ int main(int argc, char *argv[])
 
     ProjectMApplication app(argc, argv);
 
-    // 1. Parse --backend from command line
+    // Parse --backend from command line
     QString requestedBackend;
     for (int i = 1; i < argc; ++i) {
         if (QString(argv[i]) == "--backend" && i + 1 < argc) {
@@ -115,13 +136,11 @@ int main(int argc, char *argv[])
         }
     }
 
-    // 2. Check QSettings
     if (requestedBackend.isEmpty()) {
         QSettings settings("projectM", "qprojectM");
         requestedBackend = settings.value("audioBackend").toString().toLower();
     }
 
-    // 3. Auto-detect
     if (requestedBackend.isEmpty()) {
         requestedBackend = autoDetectBackend();
     }
@@ -131,27 +150,86 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    QAudioBackend *backend = createBackend(requestedBackend);
-    if (!backend) {
-        qCritical() << "Unknown or disabled audio backend:" << requestedBackend;
-        return 1;
-    }
-
-    qDebug() << "Using audio backend:" << backend->backendName();
-
-    // Save the chosen backend for next launch
-    {
-        QSettings settings("projectM", "qprojectM");
-        settings.setValue("audioBackend", requestedBackend);
-    }
+    // State
+    QAudioBackend *backend = nullptr;
+    QAudioDeviceChooser *devChooser = nullptr;
+    QAction *devAction = nullptr;
+    QString activeBackendId = requestedBackend;
 
     QString config_file = readProjectMConfig(PROJECTM_PREFIX);
     QMutex audioMutex;
-
     QProjectM_MainWindow *mainWindow = new QProjectM_MainWindow(config_file, &audioMutex);
 
-    QAction audioAction(backend->backendName() + " audio settings...", mainWindow);
-    mainWindow->registerSettingsAction(&audioAction);
+    // -- Build the audio backend menu --
+    QMenu *audioMenu = new QMenu("Audio Backend", mainWindow);
+    QActionGroup *backendGroup = new QActionGroup(mainWindow);
+    backendGroup->setExclusive(true);
+
+    // Device settings action (registered with main window's settings menu)
+    devAction = new QAction("Audio device settings...", mainWindow);
+    mainWindow->registerSettingsAction(devAction);
+
+    QList<BackendEntry> backends = availableBackends();
+
+    // Function to switch backends
+    auto switchBackend = [&](const QString &newId) {
+        if (backend && activeBackendId == newId) {
+            return;
+        }
+
+        // Stop old backend
+        if (backend) {
+            backend->writeSettings();
+            backend->stop();
+            delete backend;
+            backend = nullptr;
+        }
+
+        // Tear down old device chooser
+        if (devChooser) {
+            devChooser->writeSettings();
+            delete devChooser;
+            devChooser = nullptr;
+        }
+
+        // Create and start new backend
+        backend = createBackend(newId);
+        if (!backend) {
+            qCritical() << "Failed to create backend:" << newId;
+            return;
+        }
+
+        activeBackendId = newId;
+        backend->start(mainWindow, &audioMutex);
+
+        // Create new device chooser for the new backend
+        devChooser = new QAudioDeviceChooser(backend, mainWindow);
+        QObject::disconnect(devAction, nullptr, nullptr, nullptr);
+        QObject::connect(devAction, SIGNAL(triggered()), devChooser, SLOT(open()));
+
+        // Persist choice
+        QSettings settings("projectM", "qprojectM");
+        settings.setValue("audioBackend", newId);
+
+        qDebug() << "Switched to audio backend:" << backend->backendName();
+    };
+
+    // Create backend selector actions
+    for (const BackendEntry &entry : backends) {
+        QAction *action = new QAction(entry.label, backendGroup);
+        action->setCheckable(true);
+        action->setData(entry.id);
+        if (entry.id == requestedBackend) {
+            action->setChecked(true);
+        }
+        QObject::connect(action, &QAction::triggered, [&switchBackend, entry]() {
+            switchBackend(entry.id);
+        });
+        audioMenu->addAction(action);
+    }
+
+    // Add menu to menu bar
+    mainWindow->menuBar()->addMenu(audioMenu);
 
     mainWindow->setAttribute(Qt::WA_ShowWithoutActivating, false);
     mainWindow->setWindowState(Qt::WindowNoState);
@@ -160,18 +238,22 @@ int main(int argc, char *argv[])
     mainWindow->activateWindow();
     app.processEvents();
 
-    backend->start(mainWindow, &audioMutex);
-
-    QAudioDeviceChooser devChooser(backend, mainWindow);
-    QObject::connect(&audioAction, SIGNAL(triggered()), &devChooser, SLOT(open()));
+    // Start initial backend
+    switchBackend(requestedBackend);
 
     int ret = app.exec();
 
-    mainWindow->unregisterSettingsAction(&audioAction);
-    devChooser.writeSettings();
-    backend->writeSettings();
-    backend->stop();
-    delete backend;
+    // Cleanup
+    mainWindow->unregisterSettingsAction(devAction);
+    if (devChooser) {
+        devChooser->writeSettings();
+        delete devChooser;
+    }
+    if (backend) {
+        backend->writeSettings();
+        backend->stop();
+        delete backend;
+    }
 
     return ret;
 }

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -1,0 +1,177 @@
+/**
+ * projectM -- Milkdrop-esque visualisation SDK
+ * Copyright (C)2003-2004 projectM Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * See 'LICENSE.txt' included within this release
+ *
+ */
+
+#include "QAudioBackend.hpp"
+#include "QAudioDeviceChooser.hpp"
+#include "configutil.hpp"
+#include <qprojectm_mainwindow.hpp>
+
+#include <QApplication>
+#include <QAction>
+#include <QMutex>
+#include <QSettings>
+#include <QSurfaceFormat>
+#include <QtDebug>
+
+#include <exception>
+
+#ifdef ENABLE_PIPEWIRE
+#include "QPipeWireBackend.hpp"
+#endif
+
+#ifdef ENABLE_PULSEAUDIO
+#include "QPulseAudioBackend.hpp"
+#endif
+
+#ifdef ENABLE_JACK
+#include "QJackBackend.hpp"
+#endif
+
+class ProjectMApplication : public QApplication {
+public:
+    ProjectMApplication(int& argc, char ** argv) :
+        QApplication(argc, argv) {
+    }
+    virtual ~ProjectMApplication() { }
+
+    virtual bool notify(QObject * receiver, QEvent * event) {
+        try {
+            return QApplication::notify(receiver, event);
+        } catch (std::exception& e) {
+            qCritical() << "Exception thrown:" << e.what();
+        }
+        return false;
+    }
+};
+
+static QString autoDetectBackend()
+{
+    // Prefer PipeWire > PulseAudio > JACK based on what was compiled in.
+    // Actual server availability is checked when the backend starts.
+#ifdef ENABLE_PIPEWIRE
+    return "pipewire";
+#elif defined(ENABLE_PULSEAUDIO)
+    return "pulseaudio";
+#elif defined(ENABLE_JACK)
+    return "jack";
+#else
+    return QString();
+#endif
+}
+
+static QAudioBackend* createBackend(const QString &name)
+{
+#ifdef ENABLE_PIPEWIRE
+    if (name == "pipewire") return new QPipeWireBackend();
+#endif
+#ifdef ENABLE_PULSEAUDIO
+    if (name == "pulseaudio") return new QPulseAudioBackend();
+#endif
+#ifdef ENABLE_JACK
+    if (name == "jack") return new QJackBackend();
+#endif
+    return nullptr;
+}
+
+int main(int argc, char *argv[])
+{
+    // Set default OpenGL surface format before creating QApplication
+    QSurfaceFormat format;
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    format.setVersion(3, 3);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    format.setDepthBufferSize(24);
+    format.setStencilBufferSize(8);
+    format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+    format.setSwapInterval(1);
+    QSurfaceFormat::setDefaultFormat(format);
+
+    ProjectMApplication app(argc, argv);
+
+    // 1. Parse --backend from command line
+    QString requestedBackend;
+    for (int i = 1; i < argc; ++i) {
+        if (QString(argv[i]) == "--backend" && i + 1 < argc) {
+            requestedBackend = QString(argv[i + 1]).toLower();
+            break;
+        }
+    }
+
+    // 2. Check QSettings
+    if (requestedBackend.isEmpty()) {
+        QSettings settings("projectM", "qprojectM");
+        requestedBackend = settings.value("audioBackend").toString().toLower();
+    }
+
+    // 3. Auto-detect
+    if (requestedBackend.isEmpty()) {
+        requestedBackend = autoDetectBackend();
+    }
+
+    if (requestedBackend.isEmpty()) {
+        qCritical() << "No audio backend available.";
+        return 1;
+    }
+
+    QAudioBackend *backend = createBackend(requestedBackend);
+    if (!backend) {
+        qCritical() << "Unknown or disabled audio backend:" << requestedBackend;
+        return 1;
+    }
+
+    qDebug() << "Using audio backend:" << backend->backendName();
+
+    // Save the chosen backend for next launch
+    {
+        QSettings settings("projectM", "qprojectM");
+        settings.setValue("audioBackend", requestedBackend);
+    }
+
+    QString config_file = readProjectMConfig(PROJECTM_PREFIX);
+    QMutex audioMutex;
+
+    QProjectM_MainWindow *mainWindow = new QProjectM_MainWindow(config_file, &audioMutex);
+
+    QAction audioAction(backend->backendName() + " audio settings...", mainWindow);
+    mainWindow->registerSettingsAction(&audioAction);
+
+    mainWindow->setAttribute(Qt::WA_ShowWithoutActivating, false);
+    mainWindow->setWindowState(Qt::WindowNoState);
+    mainWindow->show();
+    mainWindow->raise();
+    mainWindow->activateWindow();
+    app.processEvents();
+
+    backend->start(mainWindow, &audioMutex);
+
+    QAudioDeviceChooser devChooser(backend, mainWindow);
+    QObject::connect(&audioAction, SIGNAL(triggered()), &devChooser, SLOT(open()));
+
+    int ret = app.exec();
+
+    mainWindow->unregisterSettingsAction(&audioAction);
+    devChooser.writeSettings();
+    backend->writeSettings();
+    backend->stop();
+    delete backend;
+
+    return ret;
+}

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -178,37 +178,43 @@ int main(int argc, char *argv[])
             return;
         }
 
-        // Stop old backend
-        if (backend) {
-            backend->writeSettings();
-            backend->stop();
-            delete backend;
-            backend = nullptr;
-        }
-
-        // Tear down old device chooser
-        if (devChooser) {
-            devChooser->writeSettings();
-            delete devChooser;
-            devChooser = nullptr;
-        }
-
-        // Create and start new backend
-        backend = createBackend(newId);
-        if (!backend) {
+        // Try to create and start the new backend before tearing down the old one
+        QAudioBackend *newBackend = createBackend(newId);
+        if (!newBackend) {
             qCritical() << "Failed to create backend:" << newId;
             return;
         }
 
-        activeBackendId = newId;
-        backend->start(mainWindow, &audioMutex);
+        if (!newBackend->start(mainWindow, &audioMutex)) {
+            qWarning() << "Backend" << newId << "failed to start, keeping current backend";
+            delete newBackend;
+            // Re-check the active radio button
+            for (QAction *a : backendGroup->actions()) {
+                if (a->data().toString() == activeBackendId) {
+                    a->setChecked(true);
+                }
+            }
+            return;
+        }
 
-        // Create new device chooser for the new backend
+        // New backend started successfully — tear down the old one
+        if (backend) {
+            backend->writeSettings();
+            backend->stop();
+            delete backend;
+        }
+        if (devChooser) {
+            devChooser->writeSettings();
+            delete devChooser;
+        }
+
+        backend = newBackend;
+        activeBackendId = newId;
+
         devChooser = new QAudioDeviceChooser(backend, mainWindow);
         QObject::disconnect(devAction, nullptr, nullptr, nullptr);
         QObject::connect(devAction, SIGNAL(triggered()), devChooser, SLOT(open()));
 
-        // Persist choice
         QSettings settings("projectM", "qprojectM");
         settings.setValue("audioBackend", newId);
 

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -151,10 +151,11 @@ int main(int argc, char *argv[])
     }
 
     // State
+    QHash<QString, QAudioBackend*> backendCache;
     QAudioBackend *backend = nullptr;
     QAudioDeviceChooser *devChooser = nullptr;
     QAction *devAction = nullptr;
-    QString activeBackendId = requestedBackend;
+    QString activeBackendId;
 
     QString config_file = readProjectMConfig(PROJECTM_PREFIX);
     QMutex audioMutex;
@@ -172,23 +173,27 @@ int main(int argc, char *argv[])
 
     QList<BackendEntry> backends = availableBackends();
 
+    // Get or create a backend, caching instances to avoid teardown/re-init issues
+    auto getOrCreateBackend = [&](const QString &id) -> QAudioBackend* {
+        if (backendCache.contains(id)) {
+            return backendCache.value(id);
+        }
+        QAudioBackend *b = createBackend(id);
+        if (b) {
+            backendCache.insert(id, b);
+        }
+        return b;
+    };
+
     // Function to switch backends
     auto switchBackend = [&](const QString &newId) {
-        if (backend && activeBackendId == newId) {
+        if (activeBackendId == newId) {
             return;
         }
 
-        // Try to create and start the new backend before tearing down the old one
-        QAudioBackend *newBackend = createBackend(newId);
+        QAudioBackend *newBackend = getOrCreateBackend(newId);
         if (!newBackend) {
             qCritical() << "Failed to create backend:" << newId;
-            return;
-        }
-
-        if (!newBackend->start(mainWindow, &audioMutex)) {
-            qWarning() << "Backend" << newId << "failed to start, keeping current backend";
-            delete newBackend;
-            // Re-check the active radio button
             for (QAction *a : backendGroup->actions()) {
                 if (a->data().toString() == activeBackendId) {
                     a->setChecked(true);
@@ -197,15 +202,27 @@ int main(int argc, char *argv[])
             return;
         }
 
-        // New backend started successfully — tear down the old one
-        if (backend) {
-            backend->writeSettings();
-            backend->stop();
-            delete backend;
+        // Start the new backend (may already be started if cached and still running)
+        if (!newBackend->start(mainWindow, &audioMutex)) {
+            qWarning() << "Backend" << newId << "failed to start, keeping current backend";
+            for (QAction *a : backendGroup->actions()) {
+                if (a->data().toString() == activeBackendId) {
+                    a->setChecked(true);
+                }
+            }
+            return;
         }
+
+        // Stop the old backend (but keep it cached)
+        if (backend) {
+            backend->stop();
+        }
+
+        // Tear down old device chooser
         if (devChooser) {
             devChooser->writeSettings();
             delete devChooser;
+            devChooser = nullptr;
         }
 
         backend = newBackend;
@@ -259,10 +276,11 @@ int main(int argc, char *argv[])
         devChooser->writeSettings();
         delete devChooser;
     }
-    if (backend) {
-        backend->writeSettings();
-        backend->stop();
-        delete backend;
+    // Stop and delete all cached backends
+    for (QAudioBackend *b : backendCache.values()) {
+        b->writeSettings();
+        b->stop();
+        delete b;
     }
 
     return ret;

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -213,8 +213,9 @@ int main(int argc, char *argv[])
             return;
         }
 
-        // Stop the old backend (but keep it cached)
+        // Deactivate the old backend (keep it cached but stop audio delivery)
         if (backend) {
+            backend->setActive(false);
             backend->stop();
         }
 
@@ -226,6 +227,7 @@ int main(int argc, char *argv[])
         }
 
         backend = newBackend;
+        backend->setActive(true);
         activeBackendId = newId;
 
         devChooser = new QAudioDeviceChooser(backend, mainWindow);

--- a/src/ui-unified/qprojectM-unified.cpp
+++ b/src/ui-unified/qprojectM-unified.cpp
@@ -150,6 +150,27 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // Validate against compiled-in backends. Unknown values from CLI or
+    // QSettings shouldn't leave the app running with no audio.
+    {
+        bool known = false;
+        for (const BackendEntry &entry : availableBackends()) {
+            if (entry.id == requestedBackend) {
+                known = true;
+                break;
+            }
+        }
+        if (!known) {
+            qWarning() << "Unknown or disabled audio backend:" << requestedBackend
+                       << "— falling back to auto-detect";
+            requestedBackend = autoDetectBackend();
+            if (requestedBackend.isEmpty()) {
+                qCritical() << "No audio backend available.";
+                return 1;
+            }
+        }
+    }
+
     // State
     QHash<QString, QAudioBackend*> backendCache;
     QAudioBackend *backend = nullptr;


### PR DESCRIPTION
Follow-up to PR #14, addressing kblaschke's suggestion in https://github.com/projectM-visualizer/frontend-qt/pull/14#discussion to give users runtime backend selection.

## Summary

Adds a single `projectM-qt` executable that can use any of the three audio backends (PipeWire, PulseAudio, JACK) at runtime. Backends are selectable from `Settings > Audio Backend` and the choice is persisted via QSettings.

## Architecture

- **`QAudioBackend`** — abstract base (QObject) with `start()`, `stop()`, `devices()`, `selectDevice()`, `supportsDeviceSwitching()`. Composition over inheritance — wraps existing thread classes without modifying them.
- **`QPipeWireBackend`, `QPulseAudioBackend`, `QJackBackend`** — thin adapters around the existing implementations. JACK is refactored from the old global-C-callback style into a proper class that routes audio through `mainWindow->addPCM()` (also fixes a pre-existing thread-safety issue where JACK called `projectm_pcm_add_float()` directly).
- **`QAudioDeviceChooser`** — generic device chooser dialog that works with any backend. Disabled when `supportsDeviceSwitching()` returns false (JACK).
- **Backend caching** — once a backend starts, it stays alive. Switching just deactivates the old one and activates the new. Required because PipeWire and PulseAudio can't be cleanly torn down and re-initialized within the same process.
- **Auto-detect priority** — PipeWire > PulseAudio > JACK based on what was compiled in. Override via `--backend pipewire|pulseaudio|jack` CLI flag or QSettings.

## Build modes

- `cmake -DENABLE_PIPEWIRE=ON` — unified binary contains only PipeWire, no menu choice
- `cmake -DENABLE_PIPEWIRE=ON -DENABLE_PULSEAUDIO=ON -DENABLE_JACK=ON` — all three available, menu lets user switch

The standalone `projectM-pipewire` / `projectM-pulseaudio` / `projectM-jack` targets still build for backward compatibility.

## Notable fixes during development

- **PipeWire re-init crash** — `pw_init`/`pw_deinit` aren't designed for repeated calls; guard with a one-shot flag
- **JACK connection freeze** — `jack_client_open` can block indefinitely if the server socket is unresponsive; wrap in a thread with 3-second timeout, use `JackNoStartServer`
- **Switch fallback** — if the new backend's `start()` fails (no server, etc), keep the current backend running and revert the radio selection

## Files changed
- 16 new files (abstract backend, 3 adapters, generic chooser dialog, configutil, unified main, CMake)
- 3 modified (CMakeLists, missing PA writeSettings, PipeWire init guard)

## Test plan
- [x] Clean build with all three backends
- [x] PipeWire auto-detected on startup
- [x] Switch to PulseAudio via menu (works since PipeWire provides PA compat)
- [x] Switch to JACK via `pw-jack projectM-qt --backend jack` (happy path) — connects, audio flows
- [x] Switch to JACK with no server (sad path) — fails fast, reverts to previous backend
- [ ] Tested locally end-to-end across all three backends with audio playing
- [ ] Settings dialog persistence verified after backend switch